### PR TITLE
Version Automation

### DIFF
--- a/SlipInfo/SlipInfo.csproj
+++ b/SlipInfo/SlipInfo.csproj
@@ -8,12 +8,18 @@
     <Version>1.0.5</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
+    <Configurations>Debug;Release</Configurations>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    <PackageReference Include="MinVer" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="UnityEngine.Modules" Version="2021.3.32" IncludeAssets="compile" />
   </ItemGroup>
@@ -33,4 +39,10 @@
       <HintPath>lib/com.mosadie.mocore.dll</HintPath>
     </Reference>
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Message Text="Packaging using tcli..." />
+    <Exec Command="echo $(MinVerVersion) / $(MinVerMajor) / $(MinVerMinor) / $(MinVerPatch) / $(MinVerPreRelease) / $(MinVerMetadata)" />
+    <Exec Command="tcli build --package-version $(MinVerVersion)" WorkingDirectory=".." />
+  </Target>
 </Project>

--- a/SlipInfo/SlipInfo.csproj
+++ b/SlipInfo/SlipInfo.csproj
@@ -5,12 +5,19 @@
     <AssemblyName>com.mosadie.slipinfo</AssemblyName>
     <Product>SlipInfo</Product>
     <Description>Local API for getting game state information</Description>
-    <Version>1.0.5</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release</Configurations>
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
+
+  <!-- Taken from Xilophor/Lethal-Company-Mod-Templates to set Mod Version correctly -->
+  <Target Name="SetModVersion" BeforeTargets="AddGeneratedFile" DependsOnTargets="MinVer">
+    <PropertyGroup>
+      <PlainVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</PlainVersion>
+      <BepInExPluginVersion>$(PlainVersion)</BepInExPluginVersion>
+    </PropertyGroup>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
@@ -40,9 +47,8 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)' == 'Release'">
     <Message Text="Packaging using tcli..." />
-    <Exec Command="echo $(MinVerVersion) / $(MinVerMajor) / $(MinVerMinor) / $(MinVerPatch) / $(MinVerPreRelease) / $(MinVerMetadata)" />
-    <Exec Command="tcli build --package-version $(MinVerVersion)" WorkingDirectory=".." />
+    <Exec Command="tcli build --package-version $(MinVerMajor).$(MinVerMinor).$(MinVerPatch)" WorkingDirectory=".." />
   </Target>
 </Project>

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -4,12 +4,12 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "MoSadie"
 name = "SlipInfo"
-versionNumber = "1.0.5"
 description = "Local HTTP server to get game state info!"
 websiteUrl = "https://github.com/MoSadie/SlipInfo"
 containsNsfwContent = false
 [package.dependencies]
 BepInEx-BepInExPack= "5.4.2100"
+MoSadie-MoCore= "1.0.0"
 
 
 [build]


### PR DESCRIPTION
Automatically bumps the version number based on the last tagged commit. No more manually updating the version number in multiple locations!

No user-facing changes.